### PR TITLE
Minor tweaks to enable compilation of smart_lcc and smart_lcc_combined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,8 +115,8 @@ function(bootloader_build_combined NAME)
             COMMAND ${CMAKE_OBJCOPY} -Obinary ${COMBINED}.elf ${COMBINED}.bin
     )
     add_custom_command(TARGET ${COMBINED} POST_BUILD
-            COMMAND ELF2UF2 ${COMBINED}.elf ${COMBINED}.uf2
-            VERBATIM)
+        COMMAND ${PICO_SDK_PATH}/build/_deps/picotool/picotool uf2 convert ${COMBINED}.elf ${COMBINED}.uf2
+        VERBATIM)
 endfunction()
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/lib/no-OS-FatFS/src build)

--- a/lib/no-OS-FatFS/src/sd_driver/SDIO/rp2040_sdio.c
+++ b/lib/no-OS-FatFS/src/sd_driver/SDIO/rp2040_sdio.c
@@ -23,6 +23,7 @@
 #include "sd_card.h"
 #include "my_debug.h"
 #include "util.h"
+#include "hardware/gpio.h"  // Add this at the top with other includes
 
 // #define azdbg(Params...)DMA_CH
 // #define azlog(Params...)
@@ -839,13 +840,8 @@ bool rp2040_sdio_init(sd_card_t *sd_card_p, float clk_div) {
     // Because the CLK is driven synchronously to CPU clock,
     // there should be no metastability problems.
     SDIO_PIO->input_sync_bypass |= (1 << SDIO_CLK) | (1 << SDIO_CMD) | (1 << SDIO_D0) | (1 << SDIO_D1) | (1 << SDIO_D2) | (1 << SDIO_D3);
+    gpio_function_t fn = pio1 == SDIO_PIO ? GPIO_FUNC_PIO1 : GPIO_FUNC_PIO0;
 
-    // Redirect GPIOs to PIO
-    enum gpio_function fn;
-    if (pio1 == SDIO_PIO) 
-        fn = GPIO_FUNC_PIO1;
-    else
-        fn = GPIO_FUNC_PIO0; 
     gpio_set_function(SDIO_CMD, fn);
     gpio_set_function(SDIO_CLK, fn);
     gpio_set_function(SDIO_D0, fn);

--- a/src/Controller/Core1/EspFirmware.cpp
+++ b/src/Controller/Core1/EspFirmware.cpp
@@ -42,21 +42,16 @@ void EspFirmware::onUartRx() {
 }
 
 bool EspFirmware::readFromRingBufferBlockingWithTimeout(uint8_t *dst, size_t len, absolute_time_t timeout_time) {
-    timeout_state_t ts;
-    check_timeout_fn timeout_check = init_single_timeout_until(&ts, timeout_time);
-
     for (size_t i = 0; i < len; ++i) {
         while (ringbuffer.readAvailable() < len) {
-            if (timeout_check(&ts)) {
+            if (time_reached(timeout_time)) {
                 return false;
             }
-
             tight_loop_contents();
         }
     }
 
     size_t readLen = ringbuffer.readBuff(dst, len);
-
     return readLen == len;
 }
 

--- a/src/utils/UartReadBlockingTimeout.h
+++ b/src/utils/UartReadBlockingTimeout.h
@@ -1,29 +1,20 @@
-//
-// Created by Magnus Nordlander on 2022-12-24.
-//
-
 #ifndef SMART_LCC_UARTREADBLOCKINGTIMEOUT_H
 #define SMART_LCC_UARTREADBLOCKINGTIMEOUT_H
 
 #include "hardware/uart.h"
 #include "hardware/gpio.h"
-#include "pico/timeout_helper.h"
+#include "pico/time.h"
 
 static inline bool uart_read_blocking_timeout(uart_inst_t *uart, uint8_t *dst, size_t len, absolute_time_t timeout_time) {
-    timeout_state_t ts;
-    check_timeout_fn timeout_check = init_single_timeout_until(&ts, timeout_time);
-
     for (size_t i = 0; i < len; ++i) {
         while (!uart_is_readable(uart)) {
-            if (timeout_check(&ts)) {
+            if (time_reached(timeout_time)) {
                 return false;
             }
-
             tight_loop_contents();
         }
         *dst++ = uart_get_hw(uart)->dr;
     }
-
     return true;
 }
 


### PR DESCRIPTION
Made some modifications to fix timeout issues, and referencing SD card to enable `smart_lcc` to compile

Had to use `picotool` instead of `ELF2UF2` to get the UF2 file created for `smart_lcc_combined`